### PR TITLE
Removed 'yum update' from distributed deployment

### DIFF
--- a/distributed/argus-centos7/bdii/Dockerfile
+++ b/distributed/argus-centos7/bdii/Dockerfile
@@ -3,7 +3,6 @@ FROM centos:7
 # Layer: base
 RUN yum install -y http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/updates/umd-release-4.1.3-1.el7.centos.noarch.rpm && \
     yum install -y https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm && \
-    yum update -y && \
     yum install -y git puppet redhat-lsb && \
     yum clean all
 

--- a/distributed/argus-centos7/pap/Dockerfile
+++ b/distributed/argus-centos7/pap/Dockerfile
@@ -4,7 +4,6 @@ FROM centos:7
 RUN yum install -y http://linuxsoft.cern.ch/wlcg/centos7/x86_64/wlcg-repo-1.0.0-1.el7.noarch.rpm && \
     yum install -y http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/updates/umd-release-4.1.3-1.el7.centos.noarch.rpm && \
     yum install -y https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm && \
-    yum update -y && \
     yum install -y git puppet redhat-lsb wget && \
     yum clean all
 

--- a/distributed/argus-centos7/pdp/Dockerfile
+++ b/distributed/argus-centos7/pdp/Dockerfile
@@ -4,7 +4,6 @@ FROM centos:7
 RUN yum install -y http://linuxsoft.cern.ch/wlcg/centos7/x86_64/wlcg-repo-1.0.0-1.el7.noarch.rpm && \
     yum install -y http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/updates/umd-release-4.1.3-1.el7.centos.noarch.rpm && \
     yum install -y https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm && \
-    yum update -y && \
     yum install -y git puppet redhat-lsb wget && \
     yum clean all
 

--- a/distributed/argus-centos7/pep/Dockerfile
+++ b/distributed/argus-centos7/pep/Dockerfile
@@ -4,7 +4,6 @@ FROM centos:7
 RUN yum install -y http://linuxsoft.cern.ch/wlcg/centos7/x86_64/wlcg-repo-1.0.0-1.el7.noarch.rpm && \
     yum install -y http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/updates/umd-release-4.1.3-1.el7.centos.noarch.rpm && \
     yum install -y https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm && \
-    yum update -y && \
     yum install -y git puppet redhat-lsb wget && \
     yum clean all
 


### PR DESCRIPTION
This was causing a jenkins fail when building the docker image of the distributed deployment, e.g. 
https://ci.cloud.cnaf.infn.it/blue/organizations/jenkins/docker_build-argus-deployment-images/detail/docker_build-argus-deployment-images/1554/pipeline/29/
